### PR TITLE
Add error when extra_repos contains external repos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,9 @@ Version: 0.0.0.9000
 Authors@R: c(
     person("Maëlle", "Salmon", , "maelle.salmon@yahoo.se", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2815-0399")),
-    person("Jeroen", "Ooms", , "jeroen@berkeley.edu", role = "aut")
+    person("Jeroen", "Ooms", , "jeroen@berkeley.edu", role = "aut"),
+    person("Hugo", "Gruson", role = "ctb",
+           comment = c(ORCID = "0000-0002-4094-1476"))
   )
 Description: Provide functionality to download archives (backups) for all repositories in a GitHub organization (useful for backups!).
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,6 @@ Imports:
     withr
 URL: https://github.com/ropensci-org/gitcellar
 BugReports: https://github.com/ropensci-org/gitcellar/issues
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gitcellar 0.0.0.9000
 
+* Asking for repositories from an external organization in `extra_repos` now 
+  return an error (#10, @Bisaloo)
+
 * Fix GitHub PAT finding for the curl step (#6, @k-doering-NOAA).
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/organization.R
+++ b/R/organization.R
@@ -26,6 +26,16 @@ download_organization_repos <- function(organizations = NULL,
   if (!dir.exists(dest_folder)) dir.create(dest_folder)
   withr::local_dir(dest_folder)
 
+  external_repos <- extra_repos[!names(extra_repos) %in% organizations]
+
+  if (length(external_repos) > 0) {
+    warning(
+      "The following repos belong to external organizations and have been ",
+      "dropped: ", paste(external_repos, collapse = ", ")
+    )
+    extra_repos <- setdiff(extra_repos, external_repos)
+  }
+
   repos <- purrr::map(organizations, launch_org_migrations, extra_repos = extra_repos) |>
     unlist(recursive = FALSE)
 

--- a/R/organization.R
+++ b/R/organization.R
@@ -31,7 +31,7 @@ download_organization_repos <- function(organizations = NULL,
   if (length(external_repos) > 0) {
     warning(
       "The following repos belong to external organizations and have been ",
-      "dropped: ", paste(external_repos, collapse = ", ")
+      "dropped: ", toString(external_repos)
     )
     extra_repos <- setdiff(extra_repos, external_repos)
   }

--- a/R/organization.R
+++ b/R/organization.R
@@ -29,11 +29,10 @@ download_organization_repos <- function(organizations = NULL,
   external_repos <- extra_repos[!names(extra_repos) %in% organizations]
 
   if (length(external_repos) > 0) {
-    warning(
-      "The following repos belong to external organizations and have been ",
-      "dropped: ", toString(external_repos)
+    stop(
+      "The following repos belong to external organizations: ",
+      toString(external_repos)
     )
-    extra_repos <- setdiff(extra_repos, external_repos)
   }
 
   repos <- purrr::map(organizations, launch_org_migrations, extra_repos = extra_repos) |>

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(gitcellar)
+
+test_check("gitcellar")

--- a/tests/testthat/test-download_organization_repos.R
+++ b/tests/testthat/test-download_organization_repos.R
@@ -1,0 +1,8 @@
+test_that("external repos in `extra_repos` trigger an error", {
+
+  expect_error(
+    download_organization_repos("maelle-test", extra_repos = c("cran" = "sf")),
+    "external organizations"
+  )
+
+})


### PR DESCRIPTION
I initially misunderstood the role of the `extra_repos` argument and thought it was used to download a list of repos outside the stated `organizations`. I believe this warning can make things clearer. 

One possible downside is that, being a warning, it will not be printed immediately (unless we set `immediate. = TRUE` but I've never seen anyone doing this so not sure it's good practice). Would a message/error be better?